### PR TITLE
Feature/FAB-43454: Remove the "ID" name from scheduled event parameter for PHP8 compat

### DIFF
--- a/content-update-scheduler.php
+++ b/content-update-scheduler.php
@@ -507,11 +507,11 @@ class ContentUpdateScheduler {
 			add_action( 'save_post', array( 'ContentUpdateScheduler', 'save_meta' ), 10, 2 );
 		} elseif ( 'trash' === $new_status ) {
 			wp_clear_scheduled_hook( 'cus_publish_post', array(
-				'ID' => $post->ID,
+                $post->ID,
 			) );
 		} elseif ( 'trash' === $old_status && $new_status === self::$_cus_publish_status ) {
 			wp_schedule_single_event( get_post_meta( $post->ID, self::$_cus_publish_status . '_pubdate', true ), 'cus_publish_post', array(
-				'ID' => $post->ID,
+                $post->ID,
 			) );
 		}
 	}
@@ -698,12 +698,12 @@ class ContentUpdateScheduler {
 				}
 
 				wp_clear_scheduled_hook( 'cus_publish_post', array(
-					'ID' => $post_id,
+                    $post_id,
 				) );
 				if ( ! $stampchange || ContentUpdateScheduler_Options::get( 'tsu_nodate' ) === 'publish' ) {
 					update_post_meta( $post_id, $pub, $stamp );
 					wp_schedule_single_event( $stamp, 'cus_publish_post', array(
-						'ID' => $post_id,
+                        $post_id,
 					) );
 				}
 			}


### PR DESCRIPTION
https://immediateco.atlassian.net/browse/FAB-43454


The plugin uses WP cron to schedule and run the tasks of updating the post. 

Since PHP8 upgrade, we can see the following error in DataDog:

`Uncaught Exception Error: "Unknown named parameter $ID" at /opt/wordpress/wp-includes/class-wp-hook.php line 307`
<img width="332" alt="Screenshot 2023-01-17 at 13 19 00" src="https://user-images.githubusercontent.com/59701039/212909229-325033b6-1216-41b9-a6ad-7aa7a0700f83.png">


[[dd link](https://app.datadoghq.com/logs?query=env%3Afeature-fab-42830-1%20service%3Aphp-fpm%20Unknown%20named%20parameter%20%24ID&agg_q=status%2Cservice&cols=host%2Cservice&event=AgAAAYWm56quK57C-AAAAAAAAAAYAAAAAEFZV201NzRtQUFEeTNvZ0VoMjhsUkFBQQAAACQAAAAAMDE4NWE3OTEtMGE5Mi00OWJmLThiMzEtNDg5OTUyYTlkNDJm&index=&messageDisplay=inline&sort_m=%2C&sort_t=%2C&stream_sort=time%2Cdesc&top_n=10%2C10&top_o=top%2Ctop&viz=pattern&x_missing=true%2Ctrue&from_ts=1673356712663&to_ts=1673961512663&live=true)]


The WP cron execution is interrupted by that error and the scheduled content update is not being completed.

This implements a fix so that we don't save the post Id in the named format (E.g. `ID => 1234`). Instead, we save it as a single integer when scheduling the update action on post save.
Using a single Id as a parameter still works and is passed to the [relevant filter](https://github.com/immediate-media/content-update-scheduler/blob/master/content-update-scheduler.php#L724)


