### PR TITLE
Feature/FAB-44086: Attempt to read property "post_type" on null (content-update-scheduler.php:177)

### DIFF
--- a/content-update-scheduler.php
+++ b/content-update-scheduler.php
@@ -171,9 +171,14 @@ class ContentUpdateScheduler {
 	 */
 	public static function display_post_states( $states ) {
 		global $post;
-		$arg = get_query_var( 'post_status' );
+
+        if (!$post instanceof WP_Post) {
+            return $states;
+        }
+
+        $arg = get_query_var( 'post_status' );
 		$the_post_types = self::get_post_types();
-		// default states for non public posts.
+		// default states for non-public posts.
 		if ( ! isset( $the_post_types[ $post->post_type ] ) ) {
 			return $states;
 		}

--- a/content-update-scheduler.php
+++ b/content-update-scheduler.php
@@ -170,15 +170,15 @@ class ContentUpdateScheduler {
 	 * @global $post
 	 */
 	public static function display_post_states( $states ) {
-		global $post;
+        global $post;
 
         if (!$post instanceof WP_Post) {
             return $states;
         }
 
-        $arg = get_query_var( 'post_status' );
-		$the_post_types = self::get_post_types();
-		// default states for non-public posts.
+        $arg = get_query_var('post_status');
+        $the_post_types = self::get_post_types();
+        // default states for non-public posts.
 		if ( ! isset( $the_post_types[ $post->post_type ] ) ) {
 			return $states;
 		}

--- a/content-update-scheduler.php
+++ b/content-update-scheduler.php
@@ -170,15 +170,15 @@ class ContentUpdateScheduler {
 	 * @global $post
 	 */
 	public static function display_post_states( $states ) {
-        global $post;
+		global $post;
 
-        if (!$post instanceof WP_Post) {
-            return $states;
-        }
+		if (!$post instanceof WP_Post) {
+			return $states;
+		}
 
-        $arg = get_query_var('post_status');
-        $the_post_types = self::get_post_types();
-        // default states for non-public posts.
+		$arg = get_query_var('post_status');
+		$the_post_types = self::get_post_types();
+		// default states for non-public posts.
 		if ( ! isset( $the_post_types[ $post->post_type ] ) ) {
 			return $states;
 		}

--- a/content-update-scheduler.php
+++ b/content-update-scheduler.php
@@ -823,13 +823,13 @@ class ContentUpdateScheduler {
 	 * Wrapper function for cron automated publishing
 	 * disables the kses filters before and reenables them after the post has been published
 	 *
-	 * @param int $post_id the post's id.
+	 * @param int $ID the post's id.
 	 *
 	 * @return void
 	 */
-	public static function cron_publish_post( $post_id ) {
+	public static function cron_publish_post( $ID ) {
 		kses_remove_filters();
-		self::publish_post( $post_id );
+		self::publish_post( $ID );
 		kses_init_filters();
 	}
 
@@ -951,7 +951,7 @@ class ContentUpdateScheduler {
 }
 
 add_action( 'save_post', array( 'ContentUpdateScheduler', 'save_meta' ), 10, 2 );
-add_action( 'cus_publish_post', array( 'ContentUpdateScheduler', 'cron_publish_post' ) );
+add_action( 'cus_publish_post', array( 'ContentUpdateScheduler', 'cron_publish_post' ), PHP_INT_MIN );
 
 add_action( 'wp_ajax_load_pubdate', array( 'ContentUpdateScheduler', 'load_pubdate' ) );
 add_action( 'init', array( 'ContentUpdateScheduler', 'init' ), PHP_INT_MAX );


### PR DESCRIPTION
https://immediateco.atlassian.net/browse/FAB-44086

It turns out there is a legacy function in the content update scheduler which tries to access the global post object on pages where the post doesn't exist. 

<img width="534" alt="Screenshot 2023-01-24 at 14 37 08" src="https://user-images.githubusercontent.com/59701039/214611235-66617fe7-31ac-4a00-8e7f-09edf7cfbea6.png">


The defensive code against that is now in place. Also added a small fix to the `cron_publish_post` method execution order to ensure it's always fired first for `cus_publish_post`. This ensures the content is still updated even if other hooks fail along the way, e.g. Wonolog stuff.
The post ID parameter was amended to support the legacy entries params.

<img width="849" alt="Screenshot 2023-01-24 at 15 55 31" src="https://user-images.githubusercontent.com/59701039/214611032-a4abd215-7153-445c-a8cc-8512464a0d2d.png">
